### PR TITLE
fix 'already initialized constant' warning

### DIFF
--- a/libraries/start_stop.rb
+++ b/libraries/start_stop.rb
@@ -21,7 +21,7 @@ class Chef
       include Chef::Mixin::ShellOut
       include Chef::MonitWrapper::Status
 
-      DEFAULT_MONIT_SERVICE_HOST_PORT_TIMEOUT_SEC = 60
+      DEFAULT_MONIT_SERVICE_HOST_PORT_TIMEOUT_SEC ||= 60
 
       # Starts the given Monit service. Waits for the service status to stabilize before and after
       # issuing the start command. If a host/port combination is specified, waits for the given host


### PR DESCRIPTION
All my chefspec tests on cookbooks that include monit_wrapper were getting the warning:

<code>
/tmp/d20150708-29343-16dccrp/cookbooks/monit_wrapper/libraries/start_stop.rb:24: warning: already initialized constant Chef::MonitWrapper::StartStop::DEFAULT_MONIT_SERVICE_HOST_PORT_TIMEOUT_SEC
/tmp/d20150708-29343-glfj1e/cookbooks/monit_wrapper/libraries/start_stop.rb:24: warning: previous definition of DEFAULT_MONIT_SERVICE_HOST_PORT_TIMEOUT_SEC was here
</code>

This will clean that up.
