### PR TITLE
Added method checks for source_url and issues_url. 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -18,8 +18,8 @@ maintainer_email 'mbautin@clearstorydata.com'
 license          'Apache License 2.0'
 description      'A wrapper around Monit making it easier to monitor services'
 version          '3.3.0'
-source_url       'https://github.com/clearstorydata-cookbooks/monit_wrapper'
-issues_url       'https://github.com/clearstorydata-cookbooks/monit_wrapper/issues'
+source_url       'https://github.com/clearstorydata-cookbooks/monit_wrapper' if respond_to?(:source_url)
+issues_url       'https://github.com/clearstorydata-cookbooks/monit_wrapper/issues' if respond_to?(:issues_url)
 
 %w( debian ubuntu redhat centos fedora ).each do |os|
   supports os


### PR DESCRIPTION
These checks make this cookbook compatible with Chef 11. Currently, the latest version of Chef that is supported by AWS OpsWork is 11.10.
